### PR TITLE
Strict typescript compliance

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -3,22 +3,22 @@ import * as base64url from './base64Url';
 export interface TokenInterface {
   header: {
     [key: string]: Json;
-    alg?: string;
-    typ?: string;
+    alg: string | undefined;
+    typ: string | undefined;
   };
   payload:
     | {
         [key: string]: Json;
-        iss?: string;
-        jti?: string;
-        iat?: string | number;
-        exp?: string | number;
+        iss: string | undefined;
+        jti: string | undefined;
+        iat: string | number | undefined;
+        exp: string | number | undefined;
       }
     | string;
   signature: string;
 }
 
-export type Json = string | number | boolean | null | { [property: string]: Json } | Json[];
+export type Json = string | number | boolean | null | undefined | { [property: string]: Json } | Json[];
 
 export function decodeToken(token: string | TokenInterface): TokenInterface {
   if (typeof token === 'string') {


### PR DESCRIPTION
Optional members on TokenInterface breaks projects that want to enforce strict typescript compliance.  

Modify Json type to support undefined and explicitly override the optional properties on TokenInterface to support undefined type.


![Screenshot 2023-05-05 at 8 03 29 AM](https://user-images.githubusercontent.com/126361786/236454276-4b4c3430-db46-44f1-b726-2dbef66e9556.png)
