### PR TITLE
fix: accommodate for optional properties in index signature

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -2,13 +2,13 @@ import * as base64url from './base64Url';
 
 export interface TokenInterface {
   header: {
-    [key: string]: Json;
+    [key: string]: Json | undefined;
     alg?: string;
     typ?: string;
   };
   payload:
     | {
-        [key: string]: Json;
+        [key: string]: Json | undefined;
         iss?: string;
         jti?: string;
         iat?: string | number;


### PR DESCRIPTION
## Description

This is an alternative to #86, which fixes the index signatures not supporting optional (`undefined`) values.

#86 modifies the `Json` type adding `undefined` to it, which may be considered not technically correct. This PR proposes an alternative way that doesn't touch the `Json` type.

## Type of Change

- Bug fix

## Does this introduce a breaking change?

No.

## Are documentation updates required?

No.

## Testing information

Build the project and verify the TS compiler doesn't show errors in `decode.d.ts` for optional properties. Example:

```
Property 'alg' of type 'string | undefined' is not assignable to 'string' index type 'Json'.
```

## Checklist

- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
